### PR TITLE
tabbox: skip empty QKeySequence entries when probing depressed modifiers

### DIFF
--- a/src/tabbox/tabbox.cpp
+++ b/src/tabbox/tabbox.cpp
@@ -733,6 +733,9 @@ static bool areKeySymXsDepressed(const uint keySyms[], int nKeySyms)
 static bool areModKeysDepressedX11(const QList<QKeySequence> &shortcuts)
 {
     for (const QKeySequence &seq : shortcuts) {
+        if (seq.isEmpty()) {
+            continue;
+        }
         uint rgKeySyms[10];
         int nKeySyms = 0;
         Qt::KeyboardModifiers mod = seq[seq.count() - 1].keyboardModifiers();


### PR DESCRIPTION
areModKeysDepressedX11 iterates over a QList<QKeySequence> and reads seq[seq.count() - 1] for each entry. If seq.count() == 0, this becomes seq[UINT_MAX] (signed -1 widened to uint), an out-of-bounds access into QKeySequence's internal storage that segfaults in release builds (the Q_ASSERT_X bounds check is debug-only).

The dispatcher areModKeysDepressed() already guards the outer list (returns early if shortcuts.isEmpty()), but does not guard against an individual QKeySequence inside a non-empty list being empty, which happens whenever initShortcuts() registers an action without a default shortcut (the four alternative-mode keys) and the user has not bound one in KCM.

Observed as kwin segfault on Alt+Tab triggered through KGlobalAccel -> QAction::activate -> navigatingThroughWindows -> areModKeysDepressed -> areModKeysDepressedX11 -> QKeySequence::operator[].

The sibling helper areModKeysDepressedWayland (line 773) has the same bug pattern but is intentionally not patched here: this fork's Application::shouldUseWaylandForCompositing() returns false unconditionally (src/main.cpp), so the dispatcher's Wayland branch is unreachable and the helper is dead code that may be stripped out in a future cleanup pass.