### PR TITLE
x11: add CompositorRefreshRate setting for mixed-refresh-rate displays

### DIFF
--- a/src/backends/x11/standalone/x11_standalone_backend.cpp
+++ b/src/backends/x11/standalone/x11_standalone_backend.cpp
@@ -506,7 +506,13 @@ static int currentRefreshRate()
         }
     }
 
-    auto syncIt = std::min_element(outputs.begin(), outputs.end(), refreshRate_compare);
+    // kwinrc [Compositing]CompositorRefreshRate: 0 = Lowest (default), 1 = Highest.
+    // Exposed in the Compositor KCM as "Refresh rate on mixed displays".
+    const KConfigGroup compositingGroup = kwinApp()->config()->group(QStringLiteral("Compositing"));
+    const int policy = compositingGroup.readEntry("CompositorRefreshRate", 0);
+    auto syncIt = (policy == 1)
+        ? std::max_element(outputs.begin(), outputs.end(), refreshRate_compare)
+        : std::min_element(outputs.begin(), outputs.end(), refreshRate_compare);
     return (*syncIt)->refreshRate();
 }
 
@@ -517,6 +523,13 @@ void X11StandaloneBackend::updateRefreshRate()
         qCWarning(KWIN_X11STANDALONE) << "Bogus refresh rate" << refreshRate;
         refreshRate = 60000;
     }
+
+    const int policy = kwinApp()->config()->group(QStringLiteral("Compositing")).readEntry("CompositorRefreshRate", 0);
+    const QList<Output *> outputs = kwinApp()->outputBackend()->outputs();
+    qCWarning(KWIN_X11STANDALONE).nospace()
+        << "Compositor refresh rate set to " << refreshRate / 1000.0 << " Hz"
+        << " (policy: " << (policy == 1 ? "Highest" : "Lowest")
+        << ", outputs: " << outputs.size() << ")";
 
     m_renderLoop->setRefreshRate(refreshRate);
 }

--- a/src/kcms/compositing/compositing.ui
+++ b/src/kcms/compositing/compositing.ui
@@ -151,6 +151,35 @@ you can reset this protection but be aware that this might result in an immediat
      </layout>
     </widget>
    </item>
+   <item row="5" column="0">
+    <widget class="QLabel" name="label_CompositorRefreshRate">
+     <property name="text">
+      <string>Refresh rate on mixed displays:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="5" column="1">
+    <widget class="QComboBox" name="kcfg_CompositorRefreshRate">
+     <property name="toolTip">
+      <string>Selects which output's refresh rate drives the X11 compositor.
+On a mixed-refresh-rate setup (e.g. a 60 Hz laptop panel and a 144 Hz external monitor),
+&quot;Highest&quot; lets high-refresh displays run at their native rate at the cost of
+possible tearing or skipped frames on slower outputs.
+&quot;Lowest&quot; is the safe default (no tearing anywhere, but capped at the slowest display).
+Override per-session with the KWIN_X11_REFRESH_RATE environment variable.</string>
+     </property>
+     <item>
+      <property name="text">
+       <string>Lowest (safe default)</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>Highest (may cause tearing or dropped frames on slower displays)</string>
+      </property>
+     </item>
+    </widget>
+   </item>
    <item row="13" column="0">
     <widget class="QLabel" name="label_HiddenPreviews">
      <property name="text">

--- a/src/kcms/compositing/kwincompositing_setting.kcfg
+++ b/src/kcms/compositing/kwincompositing_setting.kcfg
@@ -33,5 +33,13 @@
        <entry name="WindowsBlockCompositing" type="Bool">
            <default>true</default>
        </entry>
+
+       <entry name="CompositorRefreshRate" type="Enum">
+           <default>Lowest</default>
+           <choices>
+               <choice name="Lowest" value="0"/>
+               <choice name="Highest" value="1"/>
+           </choices>
+       </entry>
     </group>
 </kcfg>


### PR DESCRIPTION
On mixed-refresh setups (e.g. a 60 Hz laptop panel alongside a 144 Hz external monitor) the X11 compositor previously always picked the lowest output's refresh rate to drive its single shared RenderLoop. This is the safe default — no output gets over-driven, no tearing — but it caps the higher-refresh display at 60 Hz for compositor-mediated updates, which is the wrong trade-off for many users.

Add a kwinrc setting [Compositing]CompositorRefreshRate (enum, 0 = Lowest / 1 = Highest), exposed as "Refresh rate on mixed displays" in the Compositor KCM. Default is Lowest, preserving the current safe behaviour. Switching to Highest selects the fastest output's rate at the cost of possible tearing or dropped frames on slower outputs.

The selection is backend-independent (GLX, EGL, Vulkan all share the single X11 RenderLoop) and applies on the next compositor reinit (KCM's reinit DBus signal is enough; no kwin_x11 --replace required).

The KWIN_X11_REFRESH_RATE env var and __GL_SYNC_DISPLAY_DEVICE remain higher-priority escape hatches for power users.

To make the choice observable, updateRefreshRate() now logs the applied rate and policy whenever the rate changes:

  Compositor refresh rate set to 144 Hz (policy: Highest, outputs: 2)

Potential candidate for Sonic-DE/sonic-win#30.